### PR TITLE
Add ignoreErrors flag in global configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+v0.9.9 - 09/22/15
+* Add ignoreErrors flag on global config to avoid tests error propagation
+
 v0.9.8 - 04/08/15
 * Update versions
 * Remove Node 0.8 support

--- a/README.md
+++ b/README.md
@@ -889,6 +889,7 @@ Preceptors task-independent behavior is configured in this section. It has the f
 * ```reportManager.listener``` - List of loaded listeners
 * ```coverage``` - Coverage option
 * ```plugins``` - List of plugin modules to load
+* ```ignoreErrors``` - When set, errors that occur during testing will not be triggered on the Preceptor process (default: false)
 
 ######Reporting
 The report manager describes what reporters should be used and what it should listen for to receive testing lifecycle events from unsupported clients.

--- a/bin/preceptor
+++ b/bin/preceptor
@@ -20,7 +20,12 @@ manager.run().then(function () {
 
 }, function (err) {
 	console.log("Error: ", err.stack, "\n");
-	process.exit(1);
+
+	if (manager.getConfig().shouldIgnoreErrors()) {
+		process.exit(0);
+	} else {
+		process.exit(1);
+	}
 });
 
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -75,6 +75,9 @@ var Config = Base.extend(
 			if (!_.isBoolean(this.isVerbose())) {
 				throw new Error('The "verbose" option is not a boolean.');
 			}
+			if (!_.isBoolean(this.shouldIgnoreErrors())) {
+				throw new Error('The "ignoreErrors" option is not a boolean.');
+			}
 			if (!_.isObject(this.getReportManager())) {
 				throw new Error('The "reportManager" parameter is not an object.');
 			}
@@ -119,6 +122,16 @@ var Config = Base.extend(
 		 */
 		isVerbose: function () {
 			return this.getOptions().verbose;
+		},
+
+		/**
+		 * Should errors of tests be ignored?
+		 *
+		 * @method shouldIgnoreErrors
+		 * @return {boolean}
+		 */
+		shouldIgnoreErrors: function () {
+			return this.getOptions().ignoreErrors;
 		},
 
 		/**

--- a/lib/defaults/defaultConfig.js
+++ b/lib/defaults/defaultConfig.js
@@ -4,6 +4,7 @@
 var config = {
 	"verbose": false,
 	"debug": false,
+	"ignoreErrors": false,
 
 	"reportManager": {
 		"reporter": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preceptor",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Preceptor testrunner and aggregator",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
This was added to ignore errors in tests to avoid error propagation to the Preceptor process.
